### PR TITLE
Update github action step for codecov

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,7 @@ jobs:
   security_audit:
     runs-on: ubuntu-latest
     steps:
+      - timeout-minutes: 20
       - uses: actions/checkout@v1
 
       # We don't want to cache here since we want to get fresh updates

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -7,6 +7,7 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
+      - timeout-minutes: 20
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - timeout-minutes: 20
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
@@ -33,7 +34,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
 
       - name: upload coverage to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
Since the older version times out.

Also, add max time outs to all workflow jobs so we don't get the default of 6 hours.