### PR TITLE
Update github action step for codecov

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   security_audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -6,6 +6,7 @@ on:
 jobs:
   bench:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
 
@@ -33,7 +34,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
 
       - name: upload coverage to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1.0.10
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
Since the older version times out.

Also, add max time outs to all workflow jobs so we don't get the default of 6 hours.